### PR TITLE
Add additional checks for the mesh version

### DIFF
--- a/ObjToRBXMesh/Main.cpp
+++ b/ObjToRBXMesh/Main.cpp
@@ -16,7 +16,15 @@ int main(int argc, char* argv[])
 			return EXIT_FAILURE;
 		}
 
+		if (argv[2] == NULL) {
+			std::cout << "ERROR: Mesh version must be present!";
+			return EXIT_FAILURE;
+		}
 		std::string ver = argv[2];
+		if (ver.compare("1.00") || ver.compare("1.01") || ver.compare("2.00") != 0) {
+			std::cout << "ERROR: Invaild version specified!\nMake sure the version specified is 1.00, 1.01 or 2.00";
+			return EXIT_FAILURE;
+		}
 
 		RobloxMesh rbxMesh;
 


### PR DESCRIPTION
Fixes a bug where the output mesh is 0 bytes in size when a invailid mesh version is specified